### PR TITLE
Protect turn method

### DIFF
--- a/core/Ship.java
+++ b/core/Ship.java
@@ -33,7 +33,7 @@ public abstract class Ship {
 	/**
 	 * Classes extending this will need to implement this method to program their ship behavior
 	 */
-	public abstract void doTurn(Arena arena);
+	protected abstract void doTurn(Arena arena);
 	
 	final void initializeTurn() {
 		this.moves = this.getSpeed();

--- a/ships/CustomShip.java
+++ b/ships/CustomShip.java
@@ -23,7 +23,7 @@ public class CustomShip extends Ship {
      * @return void
      */
     @Override
-    public void doTurn(Arena arena) {
+    protected void doTurn(Arena arena) {
         // Fill in your strategy here
     }
     

--- a/ships/DroneShip.java
+++ b/ships/DroneShip.java
@@ -15,7 +15,7 @@ public class DroneShip extends Ship {
     }
     
     @Override
-    public void doTurn(Arena arena) {
+    protected void doTurn(Arena arena) {
         List<Ship> enemies = this.getNearbyEnemies(arena);
         for (int m = 0; m < this.getSpeed(); m++) {
             if (enemies.size() > 0) {

--- a/ships/DummyShip.java
+++ b/ships/DummyShip.java
@@ -23,7 +23,7 @@ public class DummyShip extends Ship {
      * @return void
      */
     @Override
-    public void doTurn(Arena arena) {
+    protected void doTurn(Arena arena) {
         // Fill in your strategy here
     }
     

--- a/ships/HiveShip.java
+++ b/ships/HiveShip.java
@@ -30,7 +30,7 @@ public class HiveShip extends Ship {
      * @return void
      */
     @Override
-    public void doTurn(Arena arena) {
+    protected void doTurn(Arena arena) {
         try {
             QueenShip queen = this.getQueen(arena);
             Ship target = queen.getNextTarget(arena, this);

--- a/ships/PatrolShip.java
+++ b/ships/PatrolShip.java
@@ -14,7 +14,7 @@ public class PatrolShip extends Ship {
     }
     
     @Override
-    public void doTurn(Arena arena) {
+    protected void doTurn(Arena arena) {
         this.move(arena, Direction.WEST);
         List<Ship> nearby = this.getNearbyShips(arena);
         if (nearby.size() > 0) {

--- a/ships/QueenShip.java
+++ b/ships/QueenShip.java
@@ -28,7 +28,7 @@ public class QueenShip extends Ship {
      * @return void
      */
     @Override
-    public void doTurn(Arena arena) {
+    protected void doTurn(Arena arena) {
         if (arena.getTurn() < 2 && this.inSuicideProtocol) {
             for (int s = 0; s < this.getHealth(); s++) {
                 Coord self = this.getCoord();


### PR DESCRIPTION
We should make `protected` the weakest level of privilege for `doTurn()` so that programmers can prevent other ships from running their turn method and creating unexpected behavior but so that the game runner can still run each ship's turn at the appropriate time.

This change will allow ships to make their turn method `protected`, but ships that have `public` turn methods will still work. Any such ships should be changed to `protected`. Is there a way to prevent `doTurn()` from being a public method? That should be considered in a future update.